### PR TITLE
fix windows package path in go-with-bazel

### DIFF
--- a/books/go-with-bazel/07-cross-compile.md
+++ b/books/go-with-bazel/07-cross-compile.md
@@ -204,7 +204,7 @@ INFO: Build completed successfully, 0 total actions
 
 ```sh
 mkdir -p internal/windows
-cat << 'EOF' > internal/windows.go
+cat << 'EOF' > internal/windows/windows.go
 package windows
 
 const OsName = "defined by windows package"


### PR DESCRIPTION
I'm learning your book( https://zenn.dev/pddg/books/go-with-bazel/viewer/07-cross-compile ). THX.

I think the path to the `internal/windows` package file is incorrect when creating the file in heredoc.
This pull request corrects where windows.go is created.

#### details 

This will cause a build error.

```console
❯ mkdir -p internal/windows
cat << 'EOF' > internal/windows.go
package windows

const OsName = "defined by windows package"
EOF
cat << 'EOF' > apps/hello_world/os_windows.go
package main

import (
        "github.com/korosuke613/go-bazel-playground/internal/windows"
)

const OsName = windows.OsName
EOF
bazel run //:gazelle
INFO: Analyzed target //:gazelle (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //:gazelle up-to-date:
  bazel-bin/gazelle-runner.bash
  bazel-bin/gazelle
INFO: Elapsed time: 0.212s, Critical Path: 0.01s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/gazelle
gazelle: finding module path for import github.com/korosuke613/go-bazel-playground/internal/windows: go: -d flag is deprecated. -d=true is a no-op
go: module github.com/korosuke613/go-bazel-playground@upgrade found (v0.0.0-20241103093838-f4c1c0add0a4), but does not contain package github.com/korosuke613/go-bazel-playground/internal/windows

❯ bazel build //apps/hello_world/...
INFO: Analyzed 8 targets (0 packages loaded, 0 targets configured).
ERROR: /Users/korosuke613/ghq/github.com/korosuke613/go-bazel-playground/apps/hello_world/BUILD.bazel:26:11: Running nogo on //apps/hello_world:hello_world_lib failed: (Exit 1): builder failed: error executing RunNogo command (from target //apps/hello_world:hello_world_lib) bazel-out/darwin_arm64-opt-exec-ST-d57f47055a04/bin/external/rules_go~~go_sdk~go-bazel-playground__download_0/builder_reset/builder nogo -sdk external/rules_go~~go_sdk~go-bazel-playground__download_0 ... (remaining 30 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
nogo: missing strict dependencies:
	apps/hello_world/os_windows.go: import of "github.com/korosuke613/go-bazel-playground/internal/windows"
No dependencies were provided.
Check that imports in Go sources match importpath attributes in deps.
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 1.706s, Critical Path: 0.99s
INFO: 22 processes: 11 internal, 11 darwin-sandbox.
ERROR: Build did NOT complete successfully
```
