### PR TITLE
fix missing argument on go_oci_image in go-with-bazel

### DIFF
--- a/books/go-with-bazel/08-container-image.md
+++ b/books/go-with-bazel/08-container-image.md
@@ -402,7 +402,7 @@ ARCHS = [
     "arm64",
 ]
 
-def go_oci_image(name, base, entrypoint, srcs, architectures = ARCHS):
+def go_oci_image(name, base, entrypoint, srcs, repo_tags, architectures = ARCHS):
     """go_oci_image creates a multi-arch container image from Go binary.
 
     Args:


### PR DESCRIPTION
I'm learning your book( https://zenn.dev/pddg/books/go-with-bazel/viewer/08-container-image ). THX.

When I copied the code from the book and used the oci.bzl macro, I got the following error.

```console
❯ bazel run //apps/hello_world:image_load
ERROR: /Users/korosuke613/ghq/github.com/korosuke613/go-bazel-playground/build_tools/macros/oci.bzl:55:21: name 'repo_tags' is not defined
WARNING: Target pattern parsing failed.
ERROR: Skipping '//apps/hello_world:image_load': error loading package 'apps/hello_world': compilation of module 'build_tools/macros/oci.bzl' failed
ERROR: error loading package 'apps/hello_world': compilation of module 'build_tools/macros/oci.bzl' failed
INFO: Elapsed time: 0.158s
INFO: 0 processes.
ERROR: Build did NOT complete successfully
ERROR: Build failed. Not running target
```

It seems that the go_oci_image function is missing an argument, so this pull request fixes that.